### PR TITLE
Edited version (customizable number of ticket pairs and presets for known cities) resubmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # hamilton-lottery-simulator
 How long until I will the Hamilton lottery?<BR>
-Edited version to allow changing of the number of ticket pairs distributed daily, with presets for Broadway NYC and Chicago IL.<BR>
+Edited version to allow changing of the number of ticket pairs distributed daily, with presets for Broadway NYC, Chicago IL, and Hollywood LA.<BR>
 Original code by shiffman https://github.com/shiffman/hamilton-lottery-simulator

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # hamilton-lottery-simulator
-How long until I will the Hamilton lottery?
-Edited version to allow changing of the number of ticket pairs distributed daily, with presets for Broadway NYC and Chicago IL.
+How long until I will the Hamilton lottery?<BR>
+Edited version to allow changing of the number of ticket pairs distributed daily, with presets for Broadway NYC and Chicago IL.<BR>
 Original code by shiffman https://github.com/shiffman/hamilton-lottery-simulator

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # hamilton-lottery-simulator
 How long until I will the Hamilton lottery?
+Edited version to allow changing of the number of ticket pairs distributed daily, with presets for Broadway NYC and Chicago IL.
+Original code by shiffman https://github.com/shiffman/hamilton-lottery-simulator

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         padding: 20px;
       }
 
-      #entrants {
+      #entrants, #tickets {
         background-color: #CCC;
         padding: 2px;
       }
@@ -22,15 +22,23 @@
   <body>
     <h1>Hamilton Lottery Simulator</h1>
     <p>
-      This simulator assumes 10 pairs of tickets available each night with <span id="entrants" contenteditable>50000</span> people entering each lottery.
+      This simulator assumes <span id="tickets" contenteditable>23</span> pairs of tickets available each night with <span id="entrants" contenteditable>50000</span> people entering each lottery.
+    </p>
+
+	<p>
+		<form action="">
+		<label>Set number of ticket-pairs (can be set manually above):</label><br>
+		<input type="radio" name="city" value="23" id="cityNY" checked>Broadway - New York, NY (46 tickets)<br>
+		<input type="radio" name="city" value="22" id="cityCH">Chicago, IL (44 tickets)<br>
+		</form>
+	</p>
+	
+    <p>
+      You have a 1 in <span id="chance">2173.913043478261</span> chance of winning.
     </p>
 
     <p>
-      You have a 1 in <span id="chance">5,000</span> chance of winning.
-    </p>
-
-    <p>
-      In order to have a 99% chance of winning the lottery at least one time, you must play ~<span id="99percent">23,000</span>.
+      In order to have a 99% chance of winning the lottery at least one time, you must play ~<span id="99percent">10,000</span>.
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
 		<label>Set number of ticket-pairs (can be set manually above):</label><br>
 		<input type="radio" name="city" value="23" id="cityNY" checked>Broadway - New York, NY (46 tickets)<br>
 		<input type="radio" name="city" value="22" id="cityCH">Chicago, IL (44 tickets)<br>
+		<input type="radio" name="city" value="20" id="cityLA">Hollywood - Los Angeles, CA (40 tickets)<br>
 		</form>
 	</p>
 	

--- a/sketch.js
+++ b/sketch.js
@@ -58,7 +58,7 @@ function draw() {
 
     var results = select('#results');
 
-    if (r == 1) {
+    if (r == 0) {
       results.html('You won!');
       noLoop();
       //console.log('won lottery');

--- a/sketch.js
+++ b/sketch.js
@@ -17,11 +17,13 @@ function setup() {
   
   cityNY = select('#cityNY');
   cityCH = select('#cityCH');
-  cityNY.mousePressed(updateProbability);
-  cityCH.mousePressed(updateProbability);
+  cityLA = select('#cityLA');
+  cityNY.mouseClicked(updateProbability);
+  cityCH.mouseClicked(updateProbability);
+  cityLA.mouseClicked(updateProbability);
   
   button = select('#start');
-  button.mousePressed(startLottery);
+  button.mouseClicked(startLottery);
   
   noLoop();
 }

--- a/sketch.js
+++ b/sketch.js
@@ -18,6 +18,9 @@ function setup() {
   cityNY = select('#cityNY');
   cityCH = select('#cityCH');
   cityLA = select('#cityLA');
+  cityNY.mouseClicked(updateCity);
+  cityCH.mouseClicked(updateCity);
+  cityLA.mouseClicked(updateCity);
   cityNY.mouseClicked(updateProbability);
   cityCH.mouseClicked(updateProbability);
   cityLA.mouseClicked(updateProbability);
@@ -28,8 +31,12 @@ function setup() {
   noLoop();
 }
 
+function updateCity() {
+tickets.html(document.querySelector('input[name="city"]:checked').value);
+
+}
+
 function updateProbability() {
-  tickets.html(document.querySelector('input[name="city"]:checked').value);
   prob = entrants.html() / tickets.html();
   select('#chance').html(prob);
 

--- a/sketch.js
+++ b/sketch.js
@@ -1,6 +1,6 @@
 
 
-var prob = 5000;
+var prob = 50000/23;
 var button;
 
 var started = false;
@@ -11,16 +11,24 @@ var entrants;
 function setup() {
   noCanvas();
   entrants = select('#entrants');
+  tickets = select('#tickets');
   entrants.input(updateProbability);
-
-
+  tickets.input(updateProbability);
+  
+  cityNY = select('#cityNY');
+  cityCH = select('#cityCH');
+  cityNY.mousePressed(updateProbability);
+  cityCH.mousePressed(updateProbability);
+  
   button = select('#start');
   button.mousePressed(startLottery);
+  
   noLoop();
 }
 
 function updateProbability() {
-  prob = entrants.html() / 10;
+  tickets.html(document.querySelector('input[name="city"]:checked').value);
+  prob = entrants.html() / tickets.html();
   select('#chance').html(prob);
 
   var notwinning = (prob - 1) / (prob);


### PR DESCRIPTION
I think I found a mistake you'll want to fix even if you don't merge my changes. You'll either want to change the lines `var r = floor(random(prob));` to `var r = ceil(random(prob));` or `if (r == 1) {` to `if (r == 0) {` regardless if you use my changes, but anyway...

Here is my original reason for the pull request:

Hey, since in reality the number of ticket pairs given away has more than doubled, and is different depending which city you enter the lottery in, I made the number of ticket pairs editable and added presets for each city (except London, which hasn't opened its lottery yet).

Thank you for making this simulator. It's fun AND educational, like Hamilton.